### PR TITLE
XHR girdisine biraz ekleme yaptim

### DIFF
--- a/jargons/xhr.md
+++ b/jargons/xhr.md
@@ -7,4 +7,25 @@ tags:
 - http
 ---
 
-**XMLHttpRequest** ifadesinin kısaltmasıdir. [AJAX](/ajax) işlemlerinin temelini oluşturur. [`fetch`](/fetch) komutunun gelişi ile [deprecated](/deprecated) olmuş sayılabilir.
+**XMLHttpRequest** ifadesinin kısaltmasıdir. [AJAX](/ajax) işlemlerinin temelini oluşturur. 
+
+> **Not**
+>
+> Genel olarak, [`fetch`](/fetch) uygulama programlama arayüzünün kullanılabildiği yerlerde
+> (*hemen hemen her zaman*) [`fetch`](/fetch) kullanmayı `XMLHTTPRequest` kullanmaya tercih
+> etmek yerinde olur.
+>
+> `XMLHTTPRequest`in [`fetch`](/fetch)’e göre farklarından biri: istemin ilerlemesini 
+> görüntüleme fırsatı vermesi; diğer bir farkı da istemi sonlandırmaya ([`abort`](abort))
+> olanak sağlamasıdır.
+>
+> Gerek ilerleme raporu sunmak, gerekse istemi sonlandırmak [`fetch`](/fetch) uygulama programlama
+> arayüzünün şu anki sürümünde mümkün değildir.
+
+## Referanslar ve Ek Okuma
+
+* [That’s so Fetch (*Jake Archibald*) (*İngilizce*)](https://jakearchibald.com/2015/thats-so-fetch/)
+* [`XMLHttpRequest` (*MDN*) (*İngilizce*)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)
+* [`fetch` API (*MDN*) (*İngilizce*)]](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+
+[`fetch`](/fetch) komutunun gelişi ile [deprecated](/deprecated) olmuş sayılabilir.

--- a/jargons/xhr.md
+++ b/jargons/xhr.md
@@ -26,6 +26,6 @@ tags:
 
 * [That’s so Fetch (*Jake Archibald*) (*İngilizce*)](https://jakearchibald.com/2015/thats-so-fetch/)
 * [`XMLHttpRequest` (*MDN*) (*İngilizce*)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)
-* [`fetch` API (*MDN*) (*İngilizce*)]](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+* [`fetch` API (*MDN*) (*İngilizce*)](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
 
 [`fetch`](/fetch) komutunun gelişi ile [deprecated](/deprecated) olmuş sayılabilir.

--- a/jargons/xhr.md
+++ b/jargons/xhr.md
@@ -27,5 +27,3 @@ tags:
 * [That’s so Fetch (*Jake Archibald*) (*İngilizce*)](https://jakearchibald.com/2015/thats-so-fetch/)
 * [`XMLHttpRequest` (*MDN*) (*İngilizce*)](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)
 * [`fetch` API (*MDN*) (*İngilizce*)](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
-
-[`fetch`](/fetch) komutunun gelişi ile [deprecated](/deprecated) olmuş sayılabilir.


### PR DESCRIPTION
“deprecated” ifadesini kaldirdim: Teknik bir jardonga “deprecated” olmus sayilir minvalinde “havada kalmis” ifadeler olmaz: 
Ya deprecate olmustur; ya da olmamistir.

Yanisira bir miktar ek bilgi ekledim.

Ek not olarak:
Jargon girdilerini, **Referanslar** bolumunde ilgili MDN makalelerine linklesek gozel olur.

Ek ek not:
Referanslar bolumuna, ille Turkce tutmak zorunda degiliz kaynaklari; en kotu ihtimal, meraklisi “google çevirgen” kullanir, duzgun Turkce’ye yakin bir cevirisini okuyabilir ilgili sayfanin.